### PR TITLE
Allow <amp-iframe> tag in a custom ads code

### DIFF
--- a/output/functions.php
+++ b/output/functions.php
@@ -1728,7 +1728,7 @@ class adsforwp_output_functions{
                         if($custom_ad_code){
                             $ad_code = '<div data-ad-id="'.esc_attr($post_ad_id).'" style="text-align:-webkit-'.esc_attr($ad_alignment).'; margin-top:'.esc_attr($ad_margin_top).'px; margin-bottom:'.esc_attr($ad_margin_bottom).'px; margin-left:'.esc_attr($ad_margin_left).'px; margin-right:'.esc_attr($ad_margin_right).'px;float:'.esc_attr($ad_text_wrap).';" class="afw afw_custom afw_ad afwadid-'.esc_attr($post_ad_id).'">
                                                             '.$sponsership_label.'
-                                                            '.strip_tags($custom_ad_code,'<amp-ad><amp-embed>').'
+                                                            '.strip_tags($custom_ad_code,'<amp-ad><amp-embed><amp-iframe>').'
                                                             </div>';    
 
                         }    


### PR DESCRIPTION
I would like to allow <amp-iframe>. You did allow it in common-functions.php, but you strip away it from the file functions.php